### PR TITLE
fix: update docs to match codebase and fix typos

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ Auth. Works with Postgres. Supports multiple auth methods (Password, JWT, OTP), 
 
 ## Usage
 
-* **`auth.Init(ctx, port, db_user, db_pass, db_name)`** - Sets up the library. Connects to Postgres, prepares internal state, and verifies database schema. Must be called before doing anything else.
+* **`auth.Init(ctx, port, db_user, db_pass, db_name, host)`** - Sets up the library. Connects to Postgres, prepares internal state, and verifies database schema. Must be called before doing anything else.
 * **`auth.JWT_init(secret)`** - Initializes the JWT signing key. Required if you intend to use stateless authentication.
 * **`auth.SMTP_init(email, password, host, port)`** - Configures the SMTP client. Required for sending OTP emails.
 * **`auth.Create_space(name, authority)`** - Creates a new space with the given name. Authority determines control level for the space. Fails if space already exists or Init() was not called.

--- a/argon.go
+++ b/argon.go
@@ -28,7 +28,7 @@ var global_default_argon = argon_parameters{
 
 /*
 A function that is not generally recommended to use unless the user have the technically knowledge.
-But incase you want to use this, please ensure this is used before any API is validated.
+But in case you want to use this, please ensure this is used before any API is validated.
 */
 func (a *Auth) Default_salt_parameters(time uint32, memory uint32, threads uint8, keyLen uint32) error {
 	/*
@@ -56,7 +56,7 @@ func (a *Auth) Default_salt_parameters(time uint32, memory uint32, threads uint8
 }
 
 /*
-This function should be stricly called in the global call and not between some
+This function should be strictly called in the global call, and not between some
 random Register API.
 
 Because we only use is_pepper_present() to check, and once the program ends, we free the memory
@@ -75,8 +75,8 @@ func (a *Auth) Pepper_init(pep string) error {
 
 /*
 Although the library holds a lot of control of the functions we are making public.
-It does make sense to make a hashing functions specially something that takes a
-string and returns an argron2 string public. This is a basic functionality any library should have.
+It does make sense to make a hashing function — specifically something that takes a
+string and returns an argon2 string public. This is a basic functionality any library should have.
 
 This returns the hashes string and the generated salt.
 */

--- a/database.go
+++ b/database.go
@@ -403,7 +403,7 @@ Returns a *pgx.Conn structure.
 func db_Connect(ctx context.Context, details *db_details) (*pgxpool.Pool, error) {
 	/*
 		The password may contain multiple special characters,
-		therefore it is primodial to use, url.URL here.
+		therefore it is primordial to use, url.URL here.
 	*/
 	u := &url.URL{
 		Scheme: "postgres",

--- a/docs/argon.md
+++ b/docs/argon.md
@@ -4,11 +4,11 @@ argon.go is the part of the auth library which handles the encryption of the pas
 
 It does this using three ideas, a salt, an optional pepper and constant-time comparison.
 
-A salt is a random, unique valye generated per password and its stored openly in the db next to the hash. It basically makes every hash unique so that the attackers can’t  out which users have the same password.
+A salt is a random, unique value generated per password and its stored openly in the db next to the hash. It basically makes every hash unique so that the attackers can’t  out which users have the same password.
 
 A pepper is optional, it’s a secret value controlled by the server. If an attacker steals both the password and the hash (or the db itself) they wouldn’t be able to figure out the password without the pepper. (if implemented the pepper must be stored safely elsewhere).
 
-Contstant time comparison is used so that the attackers cannot predict how many characters of the attempted password are right based on how fast the comparison stops.
+Constant time comparison is used so that the attackers cannot predict how many characters of the attempted password are right based on how fast the comparison stops.
 
 ```go
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -12,13 +12,14 @@ type db_details struct {
 	username      string
 	password      string
 	database_name string
+	host          string
 }
 ```
 This stores the database port, password, username and database name. Its used only inside this package.
 
 ```go
 type Auth struct {
-	conn          *pgxpool.Pool
+	Conn          *pgxpool.Pool
 	argon_params  argon_parameters
 	pepper        string
 	pepper_once   sync.Once
@@ -36,7 +37,7 @@ type Auth struct {
 This struct stores everything the auth system needs.
 
 Database
-conn : - database connection pool
+Conn : - database connection pool
 
 Security
 argon_params :- password hashing settings
@@ -48,9 +49,9 @@ sync.Once:- ensures that something is set only once and prevents bugs in multi t
 Init()
 
 ```go
-func Init(ctx context.Context, port uint16, db_user, db_pass, db_name string) (*Auth, error)
+func Init(ctx context.Context, port uint16, db_user, db_pass, db_name, host string) (*Auth, error)
 ```
-This function is basically where the server starts. It first puts all the database information into a struct. Then it tried to connect to the database and returns an error incase it fails. Creating a library context allows the background tasks to run and makes way for a clean shutdown later on. Creating the Auth object makes the system exist in memory.
+This function is basically where the server starts. It first puts all the database information into a struct. Then it tried to connect to the database and returns an error in case it fails. Creating a library context allows the background tasks to run and makes way for a clean shutdown later on. Creating the Auth object makes the system exist in memory.
 
 ```go
 if err := temp.check_tables(ctx); err != nil {

--- a/docs/database.md
+++ b/docs/database.md
@@ -17,7 +17,7 @@ func (a *Auth) create_spaces(ctx context.Context) error {
             space_name TEXT PRIMARY KEY,
             authority INTEGER NOT NULL
         )`
-    _, err := a.conn.Exec(ctx, query)
+    _, err := a.Conn.Exec(ctx, query)
     ...
 }
 ```
@@ -26,12 +26,12 @@ The spaces table defines “spaces” in your application, each identified by a 
 ```go
 func (a *Auth) create_users(ctx context.Context) error {
     query := `
-        CREATE TABLE IF NOT NOT EXISTS users (
+        CREATE TABLE IF NOT EXISTS users (
             user_id TEXT PRIMARY KEY,
             password_hash TEXT NOT NULL,
             salt TEXT NOT NULL
         )`
-    _, err := a.conn.Exec(ctx, query)
+    _, err := a.Conn.Exec(ctx, query)
     ...
 }
 ```
@@ -42,7 +42,7 @@ func (a *Auth) create_roles(ctx context.Context) error {
         CREATE TABLE IF NOT EXISTS roles (
             role TEXT PRIMARY KEY
         )`
-    _, err := a.conn.Exec(ctx, query)
+    _, err := a.Conn.Exec(ctx, query)
     ...
 }
 ```
@@ -57,11 +57,11 @@ func (a *Auth) create_permissions(ctx context.Context) error {
             role TEXT NOT NULL REFERENCES roles(role) ON DELETE CASCADE,
             PRIMARY KEY (user_id, space_name, role)
         )`
-    _, err := a.conn.Exec(ctx, query)
+    _, err := a.Conn.Exec(ctx, query)
     ...
 }
 ```
-The permissions table basically assigns roles to users in paerticular spaces. It also ensures that if a user is deleted, the corresponding role is also deleted. (DELETE CASCADE).
+The permissions table basically assigns roles to users in particular spaces. It also ensures that if a user is deleted, the corresponding role is also deleted. (DELETE CASCADE).
 
 ```go
 func (a *Auth) create_otps(ctx context.Context) error {
@@ -71,7 +71,7 @@ func (a *Auth) create_otps(ctx context.Context) error {
             code TEXT NOT NULL,
             expires_at TIMESTAMP NOT NULL
         )`
-    _, err := a.conn.Exec(ctx, query)
+    _, err := a.Conn.Exec(ctx, query)
     ...
 }
 ```
@@ -85,7 +85,7 @@ func (a *Auth) check_spaces(ctx context.Context) error {
         WHERE table_name = 'spaces'
         ORDER BY ordinal_position;
     `
-    rows, err := a.conn.Query(ctx, query)
+    rows, err := a.Conn.Query(ctx, query)
     ...
 }
 ```
@@ -99,7 +99,7 @@ func (a *Auth) check_users(ctx context.Context) error {
         WHERE table_name = 'users'
         ORDER BY ordinal_position;
     `
-    rows, err := a.conn.Query(ctx, query)
+    rows, err := a.Conn.Query(ctx, query)
     ...
 }
 ```
@@ -113,7 +113,7 @@ func (a *Auth) check_roles(ctx context.Context) error {
         WHERE table_name = 'roles'
         ORDER BY ordinal_position;
     `
-    rows, err := a.conn.Query(ctx, query)
+    rows, err := a.Conn.Query(ctx, query)
     ...
 }
 ```
@@ -127,7 +127,7 @@ func (a *Auth) check_permissions(ctx context.Context) error {
         WHERE table_name = 'permissions'
         ORDER BY ordinal_position;
     `
-    rows, err := a.conn.Query(ctx, query)
+    rows, err := a.Conn.Query(ctx, query)
     ...
 }
 ```
@@ -141,7 +141,7 @@ func (a *Auth) check_otps(ctx context.Context) error {
         WHERE table_name = 'otps'
         ORDER BY ordinal_position;
     `
-    rows, err := a.conn.Query(ctx, query)
+    rows, err := a.Conn.Query(ctx, query)
     ...
 }
 ```
@@ -156,7 +156,7 @@ func (a *Auth) table_exists(ctx context.Context, table string) (bool, error) {
             WHERE table_schema = 'public'
             AND table_name = $1
         )`
-    err := a.conn.QueryRow(ctx, query, table).Scan(&exists)
+    err := a.Conn.QueryRow(ctx, query, table).Scan(&exists)
     return exists, err
 }
 ```
@@ -189,11 +189,11 @@ func (a *Auth) check_tables(ctx context.Context) error {
 check_tables runs through each required table.For each name, it first calls table_exists; if the table is present, it runs the corresponding check function to validate the schema and if the table is missing it calls the corresponding create function to build it from scratch.
 
 ```go
-func db_connect(ctx context.Context, details *db_details) (*pgxpool.Pool, error) {
+func db_Connect(ctx context.Context, details *db_details) (*pgxpool.Pool, error) {
     u := &url.URL{
         Scheme: "postgres",
         User:   url.UserPassword(details.username, details.password),
-        Host:   fmt.Sprintf("localhost:%d", details.port),
+        Host:   fmt.Sprintf("%s:%d", details.host, details.port),
         Path:   details.database_name,
     }
     urlStr := u.String()
@@ -215,4 +215,4 @@ func db_connect(ctx context.Context, details *db_details) (*pgxpool.Pool, error)
     return pool, nil
 }
 ```
-db_connect builds a URL using net/url instead of string concatenation.After constructing urlStr, the function creates a pgxpool.then immediately runs a SELECT 1 check: if that query fails, it closes the pool and returns an error so we know the db is not reachable yet. If success,it logs that the connection pool is ready and returns it for the auth package to use.
+db_Connect builds a URL using net/url instead of string concatenation.After constructing urlStr, the function creates a pgxpool.then immediately runs a SELECT 1 check: if that query fails, it closes the pool and returns an error so we know the db is not reachable yet. If success,it logs that the connection pool is ready and returns it for the auth package to use.

--- a/docs/jwt.md
+++ b/docs/jwt.md
@@ -1,8 +1,14 @@
-#**jwt.go**
+#**jwt.go and users.go**
 
-Security is the backbone of any application. This module handles two critical jobs:
+This document covers two files: `jwt.go` and `users.go`.
+`jwt.go` handles JWT token generation and validation.
+`users.go` handles user registration, login, password changes, and deletion.
+
+Security is the backbone of any application. Together, these modules handle two critical jobs:
 1.  **Protecting User Data:** ensuring that even if the database is stolen, user passwords remain unreadable.
 2.  **Stateless Authentication:** allowing users to stay logged in without the server needing to remember them (via JWTs), which makes the application faster and easier to scale.
+
+> **Note:** The following functions (`Register_user`, `generate_salt`, `Login_user`, `Login_jwt`, `ChangePass`, `Delete_user`) are defined in `users.go`, not `jwt.go`.
 
 ## 1. Creating an Account (`Register_user`)
 When a new user signs up, we cannot simply save their password as plain text.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -37,7 +37,7 @@ The function returns true if the user has the specified role in the
 specified  space and returns false if the user does not have the role in the space or if the database connection is not initialized. 
 
 ```go
-i.conn == nil {
+a.Conn == nil {
     return false
 }
 ```

--- a/docs/spaces.md
+++ b/docs/spaces.md
@@ -8,13 +8,13 @@ This document explains the purpose and behavior of the Create_space and Delete_s
 **Create_space**
 It creates a new space entry in the database with a name and authority level and checks whether the database connection is initialized. Then it inserts a new row into the spaces table.
 In case of a successful insert i.e when there is no duplicate space name and a database connection is already initialised, the database accepts the row and no error takes place.
-Incase a duplicate space name is given, Postgres rejects it because space_name is a primary key.
-And incase the database is not initialised, no database operation happens at all. An error message ​​"run auth.Init() first as a function outside API calls" returns.
+In case a duplicate space name is given, Postgres rejects it because space_name is a primary key.
+And in case the database is not initialised, no database operation happens at all. An error message "run auth.Init() first as a function outside API calls" returns.
 
 **Delete_space**
 This works almost in the same way, but it takes the space name to be deleted.
-Incase of a successful deletion, if the database connection exists, it runs SQL and the row is deleted.
-Incase the given space does not exist, SQL still runs successfully but no row gets affected. This is not treated as an error, but nothing is deleted and  ​​"run auth.Init() first as a function outside API calls" gets returned.
+In case of a successful deletion, if the database connection exists, it runs SQL and the row is deleted.
+In case the given space does not exist, SQL still runs successfully but no row gets affected. This is not treated as an error, and no error is returned — the deletion silently succeeds.
 
 
 

--- a/jwt.go
+++ b/jwt.go
@@ -19,7 +19,7 @@ type jwt_claims struct {
 /*
 JWT_init sets the secret key used for signing and validating JWTs.
 
-This function should be stricly called in the global call,
+This function should be strictly called in the global call,
 directly after calling auth.Init().
 
 Losing or changing this secret will invalidate all existing tokens.


### PR DESCRIPTION
## What this PR does
- Updates all docs to match the current codebase
- Fixes typos across source code and docs

## Docs changes
- Added missing `host` param to Init() signature everywhere
- Fixed conn → Conn across all docs
- Fixed db_connect → db_Connect
- Corrected jwt.md to attribute user functions to users.go
- Fixed wrong error behavior description in spaces.md

## Typo fixes
- stricly → strictly
- argron2 → argon2
- primodial → primordial
- Contstant → Constant
- paerticular → particular
- NOT NOT EXISTS → NOT EXISTS
- Incase → In case
- i.conn → a.Conn